### PR TITLE
Alternativa al toString() con parentización mejorada

### DIFF
--- a/src/main/java/es/ubu/inf/tfg/regex/datos/ExpresionRegular.java
+++ b/src/main/java/es/ubu/inf/tfg/regex/datos/ExpresionRegular.java
@@ -444,6 +444,113 @@ public class ExpresionRegular {
 		return string.toString();
 	}
 
+	/**
+	 * Comprueba si el nodo es un operando.
+	 * 
+	 * @return <code>true</code> si el nodo representa un operando,
+	 *         <code>false</code> si no.
+	 */
+	public boolean esOperando() {
+		return this.esSimbolo() || this.esVacio();
+	}	
+
+	/**
+	 * Comprueba si el nodo es un operador binario.
+	 * 
+	 * @return <code>true</code> si el nodo representa un operador binario,
+	 *         <code>false</code> si no.
+	 */
+	public boolean esBinario() {
+		return this.esCierre() || this.esUnion();
+	}	
+
+	/**
+	 * Devuelve la precedencia del del nodo como un valor entero.
+	 * 
+	 * @return Precedencia del operador como valor numérico.
+	 */
+	public int precedence() {
+		switch (this.tipo) {
+		case UNION:
+			return 0;
+		case CONCAT:
+			return 1;
+		case CIERRE:
+			return 2;
+		default:
+			return -1;
+		}
+	}
+
+	/**
+	 * Construye una representación de la expresión regular, utilizando
+	 * caracteres especiales para representar las concatenaciones y los nodos
+	 * vacíos y eliminando los paréntesis cuando estos sean redundantes debido
+	 * a que con las precedencias de los operadores que combinan las sub-expresiones
+	 * es suficiente para que no haya ambigüedades en la interpretación de la expresión regular.
+	 * <p>
+	 * Formato UTF-8.
+	 */
+	public String toString2() {
+		ExpresionRegular left, right;
+		String lop, lcp, rop, rcp; // left and right, open and closing parentheses
+		StringBuilder string = new StringBuilder();
+		
+		switch (this.tipo) {
+		case VACIO:
+			// CGO changed this
+			string.append('\u03B5');
+			//string.append('E');
+			break;
+		case SIMBOLO:
+			string.append(this.simbolo);
+			break;
+		case UNION:
+		case CONCAT:
+			left = this.hijoIzquierdo;
+			right = this.hijoDerecho;
+			if (!left.esOperando() && this.precedence() > left.precedence()) {
+				lop = "(";
+				lcp = ")";
+			} else {
+				lop = "";
+				lcp = "";
+			}
+			if (!right.esOperando() && this.precedence() >= right.precedence()) {
+				rop = "(";
+				rcp = ")";
+			} else {
+				rop = "";
+				rcp = "";
+			}
+			string.append(lop);
+			string.append(this.hijoIzquierdo.toString2());
+			string.append(lcp);
+			string.append(this.tipo());
+			string.append(rop);
+			string.append(this.hijoDerecho.toString2());
+			string.append(rcp);
+			break;
+		case CIERRE:
+			if (this.hijoIzquierdo.esBinario()) {
+				lop = "(";
+				lcp = ")";
+			} else {
+				lop = "";
+				lcp = "";
+			}
+			string.append(lop);
+			string.append(this.hijoIzquierdo.toString2());
+			string.append(lcp);
+			string.append("*");
+			break;
+		default:
+			break;
+		}
+
+		return string.toString();
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (o == null)

--- a/src/test/java/es/ubu/inf/tfg/regex/datos/ExpresionRegularTest.java
+++ b/src/test/java/es/ubu/inf/tfg/regex/datos/ExpresionRegularTest.java
@@ -486,4 +486,95 @@ public class ExpresionRegularTest {
 				abuelo.profundidad());
 	}
 
+	//CGO added these	
+	/**
+	 * Comprueba que la expresión regular se imprime solo con los paréntesis indispensables
+	 */
+	@Test
+	public void testParentheses1() {
+		ExpresionRegular nodoA1 = ExpresionRegular.nodoSimbolo(1, 'a');
+
+		ExpresionRegular nodoA1estrella = ExpresionRegular.nodoCierre(nodoA1);
+		ExpresionRegular nodoB = ExpresionRegular.nodoSimbolo(2, 'b');
+		ExpresionRegular nodoBandA1estrella = ExpresionRegular.nodoConcat(nodoB, nodoA1estrella);
+		ExpresionRegular nodoE = ExpresionRegular.nodoVacio();
+		ExpresionRegular nodoEorBandA1estrella = ExpresionRegular.nodoCierre(ExpresionRegular.nodoUnion(nodoE, nodoBandA1estrella));
+		ExpresionRegular nodoC = ExpresionRegular.nodoSimbolo(3, 'c');
+
+		ExpresionRegular nodoA4 = ExpresionRegular.nodoSimbolo(4, 'a');
+		ExpresionRegular nodoDollar = ExpresionRegular.nodoAumentado(5);
+		
+		ExpresionRegular nodoCandIEorBandA1estrellaD = ExpresionRegular.nodoConcat(nodoC, nodoEorBandA1estrella);
+		ExpresionRegular nodoCandIEorBandA1estrellaDorA4 = ExpresionRegular.nodoUnion(nodoA4, nodoCandIEorBandA1estrellaD);
+		ExpresionRegular nodoER = ExpresionRegular.nodoConcat(nodoDollar, nodoCandIEorBandA1estrellaDorA4);
+		
+
+		/*
+		System.out.print("nodoER: ");
+		System.out.println(nodoER);
+		System.out.println(nodoER.toString2());
+		*/
+		
+
+		assertEquals("Problemas en la parentización de la expresión regular.", nodoER.toString2(), "((a*\u2027b|\u03B5)*\u2027c|a)\u2027$");
+	}
+
+	//CGO added these	
+	/**
+	 * Comprueba que la expresión regular se imprime solo con los paréntesis indispensables
+	 */
+	@Test
+	public void testParentheses2() {
+		ExpresionRegular nodoA = ExpresionRegular.nodoSimbolo(1, 'a');
+		ExpresionRegular nodoB = ExpresionRegular.nodoSimbolo(2, 'b');
+		ExpresionRegular nodoC = ExpresionRegular.nodoSimbolo(3, 'c');
+		ExpresionRegular nodoD = ExpresionRegular.nodoSimbolo(4, 'd');
+		ExpresionRegular nodoE = ExpresionRegular.nodoSimbolo(5, 'e');
+
+		ExpresionRegular nodoBC = ExpresionRegular.nodoConcat(nodoC, nodoB);
+		ExpresionRegular nodoABC = ExpresionRegular.nodoUnion(nodoBC, nodoA);
+		ExpresionRegular nodoDE = ExpresionRegular.nodoUnion(nodoE, nodoD);
+
+		ExpresionRegular nodoABCDE = ExpresionRegular.nodoConcat(nodoDE, nodoABC);
+		
+		/*
+		System.out.print("nodoABCDE: ");
+		System.out.println(nodoABCDE);
+		System.out.println(nodoABCDE.toString2());	
+		*/
+
+		// Ahora es "(a|b.c).(d|e)", en vez de "((a|(b·c))·(d|e))"
+		assertEquals("Problemas en la parentización de la expresión regular.", nodoABCDE.toString2(), "(a|b\u2027c)\u2027(d|e)");
+	}
+
+	//CGO added these	
+	/**
+	 * Comprueba que la expresión regular se imprime solo con los paréntesis indispensables
+	 */
+	@Test
+	public void testParentheses3() {
+		ExpresionRegular nodoA = ExpresionRegular.nodoSimbolo(1, 'a');
+		ExpresionRegular nodoB = ExpresionRegular.nodoSimbolo(2, 'b');
+		ExpresionRegular nodoC = ExpresionRegular.nodoSimbolo(3, 'c');
+		ExpresionRegular nodoD = ExpresionRegular.nodoSimbolo(4, 'd');
+		ExpresionRegular nodoE = ExpresionRegular.nodoSimbolo(5, 'e');
+
+		ExpresionRegular nodoBC = ExpresionRegular.nodoConcat(nodoC, nodoB);
+		ExpresionRegular nodoABC = ExpresionRegular.nodoConcat(nodoBC, nodoA);
+		ExpresionRegular nodoDE = ExpresionRegular.nodoUnion(nodoE, nodoD);
+		ExpresionRegular nodoDEa = ExpresionRegular.nodoCierre(nodoDE);
+		
+
+		ExpresionRegular nodoABCDE = ExpresionRegular.nodoConcat(nodoDEa, nodoABC);
+		
+		/*
+		System.out.print("nodoABCDE: ");
+		System.out.println(nodoABCDE);
+		System.out.println(nodoABCDE.toString2());	
+		*/
+
+		// Ahora es "a.(b.c).(d|e)*", en vez de "((a·(b·c))·(d|e)*)"
+		assertEquals("Problemas en la parentización de la expresión regular.", nodoABCDE.toString2(), "a\u2027(b\u2027c)\u2027(d|e)*");
+	}
+
 }


### PR DESCRIPTION
Con este nuevo método, al generar la cadena que representa la expresión
regular, se tienen en cuenta las precedencias y asociativiades de los
operadores y no se generan paréntesis innecesarios.

He preferido crear un nuevo método `toString2` en vez de sustituir el antiguo para evitar «romper» nada. Pero creo que tal cual está podrías sustituir sin problemas el `toString`original.